### PR TITLE
Resolve #8 Align gpfdist sink with GPDB5

### DIFF
--- a/spring-cloud-starter-stream-sink-gpfdist/README.adoc
+++ b/spring-cloud-starter-stream-sink-gpfdist/README.adoc
@@ -41,16 +41,16 @@ $$gpfdist.db-port$$:: $$Database port (int, default: 5432)$$ *($$Integer$$, defa
 $$gpfdist.db-user$$:: $$Database user (String, default: gpadmin)$$ *($$String$$, default: `$$gpadmin$$`)*
 $$gpfdist.delimiter$$:: $$Data line delimiter (String, default: newline character)$$ *($$String$$, default: `$$
 $$`)*
-$$gpfdist.error-table$$:: $$Tablename to log errors. (String, default: ``)$$ *($$String$$, default: `$$<none>$$`)*
 $$gpfdist.flush-count$$:: $$Flush item count (int, default: 100)$$ *($$Integer$$, default: `$$100$$`)*
 $$gpfdist.flush-time$$:: $$Flush item time (int, default: 2)$$ *($$Integer$$, default: `$$2$$`)*
 $$gpfdist.gpfdist-port$$:: $$Port of gpfdist server. Default port `0` indicates that a random port is chosen. (Integer, default: 0)$$ *($$Integer$$, default: `$$0$$`)*
+$$gpfdist.log-errors$$:: $$Enable log errors. (Boolean, default: false)$$ *($$Boolean$$, default: `$$false$$`)*
 $$gpfdist.match-columns$$:: $$Match columns with update (String, no default)$$ *($$String$$, default: `$$<none>$$`)*
 $$gpfdist.mode$$:: $$Mode, either insert or update (String, no default)$$ *($$String$$, default: `$$<none>$$`)*
 $$gpfdist.null-string$$:: $$Null string definition. (String, default: ``)$$ *($$String$$, default: `$$<none>$$`)*
 $$gpfdist.rate-interval$$:: $$Enable transfer rate interval (int, default: 0)$$ *($$Integer$$, default: `$$0$$`)*
 $$gpfdist.segment-reject-limit$$:: $$Error reject limit. (String, default: ``)$$ *($$String$$, default: `$$<none>$$`)*
-$$gpfdist.segment-reject-type$$:: $$Error reject type, either `rows` or `percent`. (String, default: ``)$$ *($$SegmentRejectType$$, default: `$$<none>$$`, possible values: `ROWS`,`PERCENT`)*
+$$gpfdist.segment-reject-type$$:: $$Error reject type, either `rows` or `percent`. (String, default: `rows`)$$ *($$SegmentRejectType$$, default: `$$<none>$$`, possible values: `ROWS`,`PERCENT`)*
 $$gpfdist.sql-after$$:: $$Sql to run after load (String, no default)$$ *($$String$$, default: `$$<none>$$`)*
 $$gpfdist.sql-before$$:: $$Sql to run before load (String, no default)$$ *($$String$$, default: `$$<none>$$`)*
 $$gpfdist.table$$:: $$Target database table (String, no default)$$ *($$String$$, default: `$$<none>$$`)*
@@ -59,7 +59,7 @@ $$spring.net.hostdiscovery.loopback$$:: $$The new loopback flag. Default value i
 $$spring.net.hostdiscovery.match-interface$$:: $$The new match interface regex pattern. Default value is is empty$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.net.hostdiscovery.match-ipv4$$:: $$Used to match ip address from a network using a cidr notation$$ *($$String$$, default: `$$<none>$$`)*
 $$spring.net.hostdiscovery.point-to-point$$:: $$The new point to point flag. Default value is FALSE$$ *($$Boolean$$, default: `$$false$$`)*
-$$spring.net.hostdiscovery.prefer-interface$$:: $$The new preferred interface list$$ *($$java.util.List<java.lang.String>$$, default: `$$<none>$$`)*
+$$spring.net.hostdiscovery.prefer-interface$$:: $$The new preferred interface list$$ *($$List<String>$$, default: `$$<none>$$`)*
 //end::configuration-properties[]
 
 == Implementation Notes
@@ -112,7 +112,7 @@ $$Error reject limit.$$ *($$String$$, default: ``)*
 Defines a `count` value in a below clause segment.
 +
 ```
-[ [LOG ERRORS INTO error_table] SEGMENT REJECT LIMIT count
+[ [LOG ERRORS] SEGMENT REJECT LIMIT count
   [ROWS | PERCENT] ]
 ```
 +
@@ -125,18 +125,18 @@ $$Error reject type, either `rows` or `percent`.$$ *($$String$$, default: ``)*
 Defines `ROWS` or `PERCENT` in below clause segment.
 +
 ```
-[ [LOG ERRORS INTO error_table] SEGMENT REJECT LIMIT count
+[ [LOG ERRORS] SEGMENT REJECT LIMIT count
   [ROWS | PERCENT] ]
 ```
-$$errorTable$$::
-$$Tablename to log errors.$$ *($$String$$, default: ``)*
+$$logErrors$$::
+$$Enable or disable log errors.$$ *($$Boolean$$, default: `false`)*
 +
-As error table is optional with `SEGMENT REJECT LIMIT`, it's only used
-if both `segmentRejectLimit` and `segmentRejectType` are set. Sets
-`error_table` in below clause segment.
+As error logging is optional with `SEGMENT REJECT LIMIT`, it's only used
+if both `segmentRejectLimit` and `segmentRejectType` are set. Enables
+the error log in below clause segment.
 +
 ```
-[ [LOG ERRORS INTO error_table] SEGMENT REJECT LIMIT count
+[ [LOG ERRORS] SEGMENT REJECT LIMIT count
   [ROWS | PERCENT] ]
 ```
 $$nullString$$::

--- a/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkConfiguration.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkConfiguration.java
@@ -100,7 +100,7 @@ public class GpfdistSinkConfiguration {
 		ReadableTableFactoryBean factoryBean = new ReadableTableFactoryBean();
 		factoryBean.setControlFile(controlFile);
 		factoryBean.setDelimiter(properties.getColumnDelimiter());
-		factoryBean.setLogErrorsInto(properties.getErrorTable());
+		factoryBean.setLogErrors(properties.isLogErrors());
 		factoryBean.setSegmentReject(properties.getSegmentRejectLimit());
 		factoryBean.setSegmentRejectType(properties.getSegmentRejectType());
 		factoryBean.setNullString(properties.getNullString());

--- a/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkProperties.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkProperties.java
@@ -135,9 +135,9 @@ public class GpfdistSinkProperties {
 	private String sqlAfter;
 
 	/**
-	 * Tablename to log errors. (String, default: ``)
+	 * Enable log errors. (Boolean, default: false)
 	 */
-	private String errorTable;
+	private boolean logErrors;
 
 	/**
 	 * Error reject limit. (String, default: ``)
@@ -145,9 +145,9 @@ public class GpfdistSinkProperties {
 	private String segmentRejectLimit;
 
 	/**
-	 * Error reject type, either `rows` or `percent`. (String, default: ``)
+	 * Error reject type, either `rows` or `percent`. (String, default: `rows`)
 	 */
-	private SegmentRejectType segmentRejectType;
+	private SegmentRejectType segmentRejectType = SegmentRejectType.ROWS;
 
 	/**
 	 * Null string definition. (String, default: ``)
@@ -322,12 +322,12 @@ public class GpfdistSinkProperties {
 		this.sqlAfter = sqlAfter;
 	}
 
-	public String getErrorTable() {
-		return errorTable;
+	public boolean isLogErrors() {
+		return logErrors;
 	}
 
-	public void setErrorTable(String errorTable) {
-		this.errorTable = errorTable;
+	public void setLogErrors(boolean logErrors) {
+		this.logErrors = logErrors;
 	}
 
 	public String getSegmentRejectLimit() {

--- a/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTable.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTable.java
@@ -22,8 +22,8 @@ package org.springframework.cloud.stream.app.gpfdist.sink.support;
  */
 public class ReadableTable extends AbstractExternalTable {
 
-	// [LOG ERRORS INTO error_table]
-	private String logErrorsInto;
+	// [LOG ERRORS]
+	private boolean logErrors;
 
 	// SEGMENT REJECT LIMIT count
 	private Integer segmentRejectLimit;
@@ -42,12 +42,12 @@ public class ReadableTable extends AbstractExternalTable {
 		this.formatHeader = formatHeader;
 	}
 
-	public String getLogErrorsInto() {
-		return logErrorsInto;
+	public boolean isLogErrors() {
+		return logErrors;
 	}
 
-	public void setLogErrorsInto(String logErrorsInto) {
-		this.logErrorsInto = logErrorsInto;
+	public void setLogErrors(boolean logErrors) {
+		this.logErrors = logErrors;
 	}
 
 	public Integer getSegmentRejectLimit() {

--- a/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTableFactoryBean.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/ReadableTableFactoryBean.java
@@ -42,7 +42,7 @@ public class ReadableTableFactoryBean implements FactoryBean<ReadableTable>, Ini
 	private Character escape;
 	private Character quote;
 	private String[] forceQuote;
-	private String logErrorsInto;
+	private boolean logErrors;
 	private Integer segmentRejectLimit;
 	private SegmentRejectType segmentRejectType;
 
@@ -61,9 +61,8 @@ public class ReadableTableFactoryBean implements FactoryBean<ReadableTable>, Ini
 		w.setLocations(locations);
 		w.setColumns(columns);
 		w.setLike(like);
-		if (StringUtils.hasText(logErrorsInto)) {
-			w.setLogErrorsInto(logErrorsInto);
-		}
+		w.setLogErrors(logErrors);
+
 		if (segmentRejectLimit != null && segmentRejectLimit > 0) {
 			w.setSegmentRejectLimit(segmentRejectLimit);
 		}
@@ -162,21 +161,21 @@ public class ReadableTableFactoryBean implements FactoryBean<ReadableTable>, Ini
 	}
 
 	/**
-	 * Gets the log errors table.
+	 * Gets if the errors are logged
 	 *
-	 * @return the log errors table
+	 * @return the if log errors is enabled
 	 */
-	public String getLogErrorsInto() {
-		return logErrorsInto;
+	public boolean isLogErrors() {
+		return logErrors;
 	}
 
 	/**
-	 * Sets the log errors table.
+	 * Sets the if the errors should be logged.
 	 *
-	 * @param logErrorsInto the new log errors table
+	 * @param logErrors if true the errors are logged in internal tables
 	 */
-	public void setLogErrorsInto(String logErrorsInto) {
-		this.logErrorsInto = logErrorsInto;
+	public void setLogErrors(boolean logErrors) {
+		this.logErrors = logErrors;
 	}
 
 	public Character getQuote() {

--- a/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SqlUtils.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SqlUtils.java
@@ -77,7 +77,7 @@ public abstract class SqlUtils {
 		buf.append(" ( ");
 		buf.append("DELIMITER '");
 		if (externalTable.getDelimiter() != null) {
-			buf.append(unicodeEscaped(externalTable.getDelimiter().charValue()));
+			buf.append(externalTable.getDelimiter().charValue());
 		}
 		else {
 			buf.append("|");
@@ -116,9 +116,8 @@ public abstract class SqlUtils {
 		}
 
 		if (externalTable.getSegmentRejectLimit() != null && externalTable.getSegmentRejectType() != null) {
-			if (externalTable.getLogErrorsInto() != null) {
-				buf.append(" LOG ERRORS INTO ");
-				buf.append(externalTable.getLogErrorsInto());
+			if (externalTable.isLogErrors()) {
+				buf.append(" LOG ERRORS ");
 			}
 			buf.append(" SEGMENT REJECT LIMIT ");
 			buf.append(externalTable.getSegmentRejectLimit());

--- a/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SqlUtils.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/main/java/org/springframework/cloud/stream/app/gpfdist/sink/support/SqlUtils.java
@@ -77,7 +77,7 @@ public abstract class SqlUtils {
 		buf.append(" ( ");
 		buf.append("DELIMITER '");
 		if (externalTable.getDelimiter() != null) {
-			buf.append(externalTable.getDelimiter().charValue());
+			buf.append(unicodeEscaped(externalTable.getDelimiter().charValue()));
 		}
 		else {
 			buf.append("|");

--- a/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkPropertiesTests.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/GpfdistSinkPropertiesTests.java
@@ -34,13 +34,13 @@ public class GpfdistSinkPropertiesTests {
 		SpringApplication app = new SpringApplication(TestConfiguration.class);
 		app.setWebEnvironment(false);
 		ConfigurableApplicationContext context = app
-				.run(new String[] { "--gpfdist.errorTable=myerror",
+				.run(new String[] { "--gpfdist.logErrors=true",
 						"--gpfdist.segmentRejectLimit=1",
 						"--gpfdist.segmentRejectType=ROWS" });
 
 		GpfdistSinkProperties properties = context.getBean(GpfdistSinkProperties.class);
 		assertThat(properties, notNullValue());
-		assertThat(properties.getErrorTable(), is("myerror"));
+		assertThat(properties.isLogErrors(), is(true));
 		assertThat(properties.getSegmentRejectLimit(), is("1"));
 		assertThat(properties.getSegmentRejectType(), is(SegmentRejectType.ROWS));
 		context.close();
@@ -51,13 +51,13 @@ public class GpfdistSinkPropertiesTests {
 		SpringApplication app = new SpringApplication(TestConfiguration.class);
 		app.setWebEnvironment(false);
 		ConfigurableApplicationContext context = app
-				.run(new String[] { "--gpfdist.errorTable=myerror",
+				.run(new String[] { "--gpfdist.logErrors=true",
 						"--gpfdist.segmentRejectLimit=1",
 						"--gpfdist.segmentRejectType=percent" });
 
 		GpfdistSinkProperties properties = context.getBean(GpfdistSinkProperties.class);
 		assertThat(properties, notNullValue());
-		assertThat(properties.getErrorTable(), is("myerror"));
+		assertThat(properties.isLogErrors(), is(true));
 		assertThat(properties.getSegmentRejectLimit(), is("1"));
 		assertThat(properties.getSegmentRejectType(), is(SegmentRejectType.PERCENT));
 		context.close();

--- a/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationIT.java
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/test/java/org/springframework/cloud/stream/app/gpfdist/sink/support/LoadConfigurationIT.java
@@ -39,7 +39,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 
 		ReadableTableFactoryBean factory1 = new ReadableTableFactoryBean();
 		factory1.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri("localhost", 1234)));
-		factory1.setLogErrorsInto("myerror");
+		factory1.setLogErrors(true);
 		factory1.setSegmentRejectLimit(2);
 		factory1.setSegmentRejectType(SegmentRejectType.ROWS);
 		factory1.afterPropertiesSet();
@@ -51,7 +51,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 		LoadConfiguration loadConfiguration = factory2.getObject();
 
 		String sql = SqlUtils.createExternalReadableTable(loadConfiguration, "xxx", null);
-		assertThat(sql, containsString("LOG ERRORS INTO myerror SEGMENT REJECT LIMIT 2 ROWS"));
+		assertThat(sql, containsString("LOG ERRORS SEGMENT REJECT LIMIT 2 ROWS"));
 		assertSql(sql);
 	}
 
@@ -64,7 +64,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 
 		ReadableTableFactoryBean factory1 = new ReadableTableFactoryBean();
 		factory1.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri("localhost", 1234)));
-		factory1.setLogErrorsInto("myerror");
+		factory1.setLogErrors(true);
 		factory1.setSegmentRejectLimit(2);
 		factory1.setSegmentRejectType(SegmentRejectType.PERCENT);
 		factory1.afterPropertiesSet();
@@ -76,7 +76,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 		LoadConfiguration loadConfiguration = factory2.getObject();
 
 		String sql = SqlUtils.createExternalReadableTable(loadConfiguration, "xxx", null);
-		assertThat(sql, containsString("LOG ERRORS INTO myerror SEGMENT REJECT LIMIT 2 PERCENT"));
+		assertThat(sql, containsString("LOG ERRORS SEGMENT REJECT LIMIT 2 PERCENT"));
 		assertSql(sql);
 	}
 
@@ -89,7 +89,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 
 		ReadableTableFactoryBean factory1 = new ReadableTableFactoryBean();
 		factory1.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri("localhost", 1234)));
-		factory1.setLogErrorsInto("myerror");
+		factory1.setLogErrors(true);
 		factory1.setSegmentReject("3%");
 		factory1.afterPropertiesSet();
 
@@ -100,7 +100,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 		LoadConfiguration loadConfiguration = factory2.getObject();
 
 		String sql = SqlUtils.createExternalReadableTable(loadConfiguration, "xxx", null);
-		assertThat(sql, containsString("LOG ERRORS INTO myerror SEGMENT REJECT LIMIT 3 PERCENT"));
+		assertThat(sql, containsString("LOG ERRORS SEGMENT REJECT LIMIT 3 PERCENT"));
 		assertSql(sql);
 	}
 
@@ -113,7 +113,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 
 		ReadableTableFactoryBean factory1 = new ReadableTableFactoryBean();
 		factory1.setLocations(Arrays.asList(NetworkUtils.getGPFDistUri("localhost", 1234)));
-		factory1.setLogErrorsInto("myerror");
+		factory1.setLogErrors(true);
 		factory1.setSegmentRejectLimit(2);
 		factory1.setSegmentRejectType(SegmentRejectType.ROWS);
 		// 3% overrides manually set 2 and ROWS
@@ -127,7 +127,7 @@ public class LoadConfigurationIT extends AbstractDbTests {
 		LoadConfiguration loadConfiguration = factory2.getObject();
 
 		String sql = SqlUtils.createExternalReadableTable(loadConfiguration, "xxx", null);
-		assertThat(sql, containsString("LOG ERRORS INTO myerror SEGMENT REJECT LIMIT 3 PERCENT"));
+		assertThat(sql, containsString("LOG ERRORS SEGMENT REJECT LIMIT 3 PERCENT"));
 		assertSql(sql);
 	}
 


### PR DESCRIPTION
- Replace the `logErrorTable` (of type String) property by `logErrors` (Boolean) property.  When the `logErrors` is set to `true` (and the rejection type & limit are not empty) then the `LOG ERROS` clause is added to the CREATE TABE statements
- Set the `segmentRejectType` property to default to `rows`