### PR TITLE
URL Cleanup

### DIFF
--- a/spring-cloud-starter-stream-sink-gpfdist/src/test/resources/LoadConfigurationFactoryBeanTests1.xml
+++ b/spring-cloud-starter-stream-sink-gpfdist/src/test/resources/LoadConfigurationFactoryBeanTests1.xml
@@ -4,9 +4,9 @@
 			 xmlns:beans="http://www.springframework.org/schema/beans"
 			 xmlns:int-groovy="http://www.springframework.org/schema/integration/groovy"
 			 xsi:schemaLocation="http://www.springframework.org/schema/beans
-		http://www.springframework.org/schema/beans/spring-beans.xsd
+		https://www.springframework.org/schema/beans/spring-beans.xsd
 		http://www.springframework.org/schema/integration
-		http://www.springframework.org/schema/integration/spring-integration.xsd">
+		https://www.springframework.org/schema/integration/spring-integration.xsd">
 
 	<beans:bean id="greenplumLoadConfiguration" class="org.springframework.cloud.stream.app.gpfdist.sink.support.LoadConfigurationFactoryBean">
 		<beans:property name="updateColumns" value="col1,col2" />


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/integration/spring-integration.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/integration/spring-integration.xsd ([https](https://www.springframework.org/schema/integration/spring-integration.xsd) result 200).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 6 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/integration with 2 occurrences
* http://www.springframework.org/schema/integration/groovy with 1 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences